### PR TITLE
fix: honor documented global config path

### DIFF
--- a/src/config-store.ts
+++ b/src/config-store.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 
@@ -15,12 +15,26 @@ import type {
   ResolvedHideMessagesConfig,
 } from "./types.js";
 
-function resolveExtensionRoot(moduleUrl = import.meta.url): string {
-  return dirname(dirname(fileURLToPath(moduleUrl)));
+function getPiAgentDir(): string {
+  const envDir = process.env.PI_CODING_AGENT_DIR;
+  if (envDir) {
+    if (envDir === "~") {
+      return homedir();
+    }
+
+    if (envDir.startsWith("~/")) {
+      return homedir() + envDir.slice(1);
+    }
+
+    return envDir;
+  }
+
+  return join(homedir(), ".pi", "agent");
 }
 
-const EXTENSION_ROOT = resolveExtensionRoot();
-const EXTENSION_CONFIG_PATH = join(EXTENSION_ROOT, CONFIG_BASENAME);
+function getGlobalConfigPath(): string {
+  return join(getPiAgentDir(), "extensions", EXTENSION_ID, CONFIG_BASENAME);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -154,9 +168,10 @@ export function loadHideMessagesConfig(
 ): HideMessagesConfigLoadResult {
   const cwd = getConfigCwd(ctx);
   const projectConfigPath = getProjectConfigPath(cwd);
+  const globalConfigPath = getGlobalConfigPath();
   const warnings: string[] = [];
 
-  const globalConfig = readConfigFile(EXTENSION_CONFIG_PATH, warnings);
+  const globalConfig = readConfigFile(globalConfigPath, warnings);
   const projectConfig = readConfigFile(projectConfigPath, warnings);
 
   let config: ResolvedHideMessagesConfig = {
@@ -168,7 +183,7 @@ export function loadHideMessagesConfig(
 
   config = mergeConfigFile(config, globalConfig);
   config = mergeConfigFile(config, projectConfig);
-  config.configPath = existsSync(projectConfigPath) ? projectConfigPath : EXTENSION_CONFIG_PATH;
+  config.configPath = existsSync(projectConfigPath) ? projectConfigPath : globalConfigPath;
 
-  return { config, warnings, projectConfigPath, globalConfigPath: EXTENSION_CONFIG_PATH };
+  return { config, warnings, projectConfigPath, globalConfigPath };
 }

--- a/src/types-shims.d.ts
+++ b/src/types-shims.d.ts
@@ -1,7 +1,14 @@
 declare namespace NodeJS {
+  interface ProcessEnv {
+    [key: string]: string | undefined;
+    HOME?: string;
+    PI_CODING_AGENT_DIR?: string;
+  }
+
   interface Process {
     pid: number;
     cwd(): string;
+    env: ProcessEnv;
   }
 }
 
@@ -14,6 +21,10 @@ declare module "node:fs" {
   export function renameSync(oldPath: string, newPath: string): void;
   export function unlinkSync(path: string): void;
   export function writeFileSync(path: string, content: string, encoding: "utf-8"): void;
+}
+
+declare module "node:os" {
+  export function homedir(): string;
 }
 
 declare module "node:path" {

--- a/test/config-store.test.ts
+++ b/test/config-store.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { loadHideMessagesConfig } from "../src/config-store.js";
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function withTempAgentDir(run: (tempHome: string) => void): void {
+  const tempHome = mkdtempSync(join(tmpdir(), "pi-hide-messages-config-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  process.env.PI_CODING_AGENT_DIR = join(tempHome, ".pi", "agent");
+
+  try {
+    run(tempHome);
+  } finally {
+    if (previousAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    }
+
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
+test("loadHideMessagesConfig reads the documented global config path", () => {
+  withTempAgentDir((tempHome) => {
+    const cwd = join(tempHome, "workspace", "project");
+    mkdirSync(cwd, { recursive: true });
+
+    const globalConfigPath = join(
+      tempHome,
+      ".pi",
+      "agent",
+      "extensions",
+      "pi-hide-messages",
+      "config.json",
+    );
+    writeJson(globalConfigPath, {
+      defaultVisibleCount: 100,
+    });
+
+    const result = loadHideMessagesConfig({ cwd });
+
+    assert.equal(result.config.defaultVisibleCount, 100);
+    assert.equal(result.config.configPath, globalConfigPath);
+    assert.equal(result.globalConfigPath, globalConfigPath);
+  });
+});
+
+test("project config overrides the documented global config path", () => {
+  withTempAgentDir((tempHome) => {
+    const cwd = join(tempHome, "workspace", "project");
+    const globalConfigPath = join(
+      tempHome,
+      ".pi",
+      "agent",
+      "extensions",
+      "pi-hide-messages",
+      "config.json",
+    );
+    const projectConfigPath = join(cwd, ".pi", "extensions", "pi-hide-messages", "config.json");
+
+    mkdirSync(cwd, { recursive: true });
+    writeJson(globalConfigPath, {
+      defaultVisibleCount: 100,
+    });
+    writeJson(projectConfigPath, {
+      defaultVisibleCount: 200,
+    });
+
+    const result = loadHideMessagesConfig({ cwd });
+
+    assert.equal(result.config.defaultVisibleCount, 200);
+    assert.equal(result.config.configPath, projectConfigPath);
+  });
+});


### PR DESCRIPTION
## Summary

- load global config from Pi's agent directory instead of the installed package root
- keep project overrides at `.pi/extensions/pi-hide-messages/config.json`
- add regression tests for documented global config loading and project override precedence

Fixes #1.

## Why

The README documents the global config path as:

```text
~/.pi/agent/extensions/pi-hide-messages/config.json
```

but the implementation was reading `<package-root>/config.json` via `import.meta.url`, which breaks npm/git installs because editing the documented global config file has no effect.

This change makes the loader honor Pi's documented global config location and `PI_CODING_AGENT_DIR` semantics.

## Validation

- `npm test`
- `npm run lint`
